### PR TITLE
Add warning to `prim` if POSCAR atomic ordering changes

### DIFF
--- a/matools/prim.py
+++ b/matools/prim.py
@@ -56,7 +56,19 @@ def main():
     print('Final structure has {} atoms'.format(prim.num_sites))
     print('Conv -> Prim transformation matrix:')
     print('\t' + str(transform).replace('\n', '\n\t'))
-
+    
+    # check if POSCAR atomic ordering has changed
+    with open(args.file) as f: # original POSCAR file
+        lines=f.readlines()
+        orig_atoms_list = lines[5].split()
+    
+    with open('{}_prim'.format(args.file)) as f: # output prim POSCAR file
+        lines=f.readlines()
+        prim_atoms_list = lines[5].split()
+    
+    if orig_atoms_list != prim_atoms_list:
+        print("Beware! POSCAR atomic ordering in POSCAR_prim does not match that of POSCAR")
+        print("Make sure to update your POTCAR to match the atomic ordering of POSCAR_prim!")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
(See SMTG Slack #vasp channel)

Quickly tested on Jupyter:
![image](https://user-images.githubusercontent.com/51478689/128360254-82eba9d2-b869-4c11-9c41-9f210919d798.png)

and be reinstalling this updated version and testing on the CLI:
![image](https://user-images.githubusercontent.com/51478689/128360592-851e18d1-d6f0-4bf1-b060-71f0ec4d7880.png)
